### PR TITLE
Allow bots to connect to non-localhost addresses

### DIFF
--- a/server/src/main/kotlin/dev/robocode/tankroyale/server/connection/ConnectionHandler.kt
+++ b/server/src/main/kotlin/dev/robocode/tankroyale/server/connection/ConnectionHandler.kt
@@ -42,7 +42,7 @@ class ConnectionHandler(
     private val gson = Gson()
 
     init {
-        val address = InetSocketAddress("localhost", Server.port)
+        val address = InetSocketAddress(Server.port)
         webSocketObserver = WebSocketObserver(address).apply {
             isTcpNoDelay = true
         }


### PR DESCRIPTION
Hardcoding localhost blocks connections using hostname or server IP address